### PR TITLE
Handle empty evaluation in calculator display

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,13 +28,15 @@ const deleteLastNumber = () => {
 }
 
 const showResult = () => {
-	try {
-		display.textContent = eval(display.textContent)
-	} catch (err) {
-		if (err != '') {
-			display.textContent = 'ERROR'
-		}
-	}
+        if (display.textContent === '') return
+        try {
+                const result = eval(display.textContent)
+                if (result !== undefined) {
+                        display.textContent = result
+                }
+        } catch (err) {
+                display.textContent = 'ERROR'
+        }
 }
 
 // THEME SELECTOR


### PR DESCRIPTION
## Summary
- avoid displaying `undefined` when pressing equals on an empty input
- simplify error handling in result calculation

## Testing
- `npm test` *(fails: no package.json)*
- `node main.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0a7cfda08322a7d834df3ffa0ddd